### PR TITLE
Rename `apis` param into `pick`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export async function main() {
   try {
     result = await zero({
       token: process.env.ZERO_TOKEN,
-      apis: ["aws"],
+      pick: ["aws"],
     }).fetch()
   } catch(error) {
     console.error(error)

--- a/src/graphql/secrets.ts
+++ b/src/graphql/secrets.ts
@@ -1,8 +1,8 @@
 import {gql} from 'graphql-request'
 
 export const Secrets = gql`
-  query Secrets($token: String!, $apis: [String!]) {
-    secrets(zeroToken: $token, pick: $apis) {
+  query Secrets($token: String!, $pick: [String!]) {
+    secrets(zeroToken: $token, pick: $pick) {
       name
 
       fields {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {Secrets} from './graphql/secrets'
 import {ResponseBody} from './types'
 const GRAPHQL_ENDPOINT_URL = 'https://core.tryzero.com/v1/graphql'
 
-export const zero = (params: {apis: Array<string>; token: string}) => {
+export const zero = (params: {pick: Array<string>; token: string}) => {
   if (typeof params.token === 'undefined' || params.token.length === 0) {
     throw new Error('Zero token should be non-empty string')
   }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -29,7 +29,7 @@ describe('Zero TypeScript SDK', () => {
     expect(() => {
       zero({
         token: '',
-        apis: ['aws'],
+        pick: ['aws'],
       }).fetch()
     }).toThrowError('Zero token should be non-empty string')
   })
@@ -38,7 +38,7 @@ describe('Zero TypeScript SDK', () => {
     await expect(
       zero({
         token: 'token',
-        apis: ['aws'],
+        pick: ['aws'],
       }).fetch(),
     ).resolves.toEqual({aws: {name: 'value', name2: 'value2'}})
   })
@@ -47,7 +47,7 @@ describe('Zero TypeScript SDK', () => {
     await expect(
       zero({
         token: 'invalid token',
-        apis: ['aws'],
+        pick: ['aws'],
       }).fetch(),
     ).resolves.toEqual({})
   })
@@ -56,7 +56,7 @@ describe('Zero TypeScript SDK', () => {
     await expect(
       zero({
         token: 'token',
-        apis: [],
+        pick: [],
       }).fetch(),
     ).rejects.toThrowError('Failed to fetch')
   })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -10,7 +10,7 @@ jest.mock('graphql-request', () => {
 
     GraphQLClient: jest.fn().mockImplementation(() => ({
       request: jest.fn().mockImplementation((_, variables) => {
-        if (variables.apis.length === 0) {
+        if (variables.pick.length === 0) {
           return Promise.reject(new Error('Failed to fetch'))
         }
 


### PR DESCRIPTION
 - use more meaningful name for secrets scope selector param `pick` the same we use for `graphql` query
 - update corresponding tests
 - update usage example